### PR TITLE
Korjaa liquid lausekkeen eksyminen rakennetun sivun css:ään

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -7,7 +7,7 @@ html {
       color: #000000;
       width: 100%;
       overflow-x: hidden; 
-      background-image: url("{{ site.img-url }}/moi.webp");
+      background-image: url(#{$img_url}/moi.webp);
       background-position: right bottom;
       background-size: 20rem;
       background-repeat: no-repeat;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,3 +1,4 @@
 ---
 ---
+$img_url: "{{ site.img-url }}";
 @import "base";


### PR DESCRIPTION
Tämän pitäisi korjata sass niin että ankka tulee takaisin sivun oikeaan alareunaan ja sivujen css ei enää olisi rikki chromella.